### PR TITLE
Filtering Paused Campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ SPREADSHEET_ID : Export the execution report into a Google Spreadsheet by adding
 
 ### Additional Parameters (for advanced use-cases)
 
+FILTER_PAUSED_CAMPAIGNS : Determines whether the script should process campaigns that are currently in a Paused state. This setting is particularly useful when the CAMPAIGNS parameter is set to ['__ALL__'].
+Set to 'TRUE' (default) to skip all paused campaigns and only analyze search terms from Enabled campaigns.
+Set to 'FALSE' if you have a specific need to analyze or add keywords to ad groups within paused campaigns (e.g., preparing a paused campaign for re-activation).
+
 IGNORE_WORDS : An array of terms that will be not be created as new keywords.
 This can replace negative keywords as a means to ensure certain words and
 phrases are not used. Please note that this is a literal list, and only exact

--- a/search_term_amp.js
+++ b/search_term_amp.js
@@ -136,6 +136,15 @@ const SPREADSHEET_ID = '';
  */
 
 /**
+ * If true, campaigns in Paused state will be ignored.
+ * Default is 'true' mainly for runtime considerations, but
+ * can be set to 'false' to include Paused campaigns
+ *
+ * @const {boolean}
+ */
+const FILTER_PAUSED_CAMPAIGNS = true;
+
+/**
  * List of words that must not be included in keywords added by the script.
  * This can be used to ensure certain words are not created as new keywords
  * while avoiding the use of negative keywords.
@@ -412,10 +421,14 @@ function getAdGroupResourceId(adGroup) {
  */
 function getCampaignNames() {
   const campaignNames = [];
-  const campaigns = AdsApp.campaigns();
+  const campaignIterator = AdsApp.campaigns().get();
 
-  for (const c of campaigns) {
-    campaignNames.push(c.getName());
+  if (FILTER_PAUSED_CAMPAIGNS) Logger.log('Ignoring Paused campaigns');
+  for (const campaign of campaignIterator) {
+    if (FILTER_PAUSED_CAMPAIGNS && !campaign.isEnabled()) {
+      continue; // Skip this campaign and move to the next one
+    }
+    campaignNames.push(campaign.getName());
   }
 
   Logger.log('All campaigns found: %s', campaignNames);


### PR DESCRIPTION
feat: Add paused campaign filter

Introduces the `FILTER_PAUSED_CAMPAIGNS` constant to prevent the script from processing inactive campaigns and improve runtime efficiency.